### PR TITLE
Replaced clunky undo feature with Action History

### DIFF
--- a/src/assets/creator-assets/drawer-arrow.svg
+++ b/src/assets/creator-assets/drawer-arrow.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 12 12" enable-background="new 0 0 12 12" xml:space="preserve">
+<g>
+    <path fill="#FFFFFF" d="M 0,0 L 12,0 L 6,10 Z" />
+</g>
+</svg>

--- a/src/creator.html
+++ b/src/creator.html
@@ -711,9 +711,13 @@
 				</div>
 			</div>
 			<tree-history ng-class="{ 'minimized':minimized }">
+				<div class="undo-redo-options">
+					<button ng-click="undoAction()" ng-disabled="historyPosition <= 0">Undo</button>
+					<button ng-click="redoAction()" ng-disabled="historyPosition >= historySize-1">Redo</button>
+				</div>
 				<header ng-click="minimized = !minimized">Action History</header>
 				<!-- <div ng-click="dumpHistory()">Dump History</div> -->
-				<div ng-repeat="item in treeHistoryItems | orderBy: '-timestamp'" ng-click="rollBackToSnapshot(item.index)">
+				<div class="action-history" ng-repeat="item in treeHistoryItems | orderBy: '-timestamp'" ng-click="rollBackToSnapshot(item.index)">
 					{{item.context}}
 				</div>
 			</tree-history>

--- a/src/creator.html
+++ b/src/creator.html
@@ -40,9 +40,6 @@
 				<p>Widget Scoring Mode</p>
 				<button type="button" class="header-options-button" ng-click="showScoreModeDialog = true; showBackgroundCover = true">{{scoreMode}}</button>
 			</div>
-
-			<button type="button" class="temp-qset-gen-button" ng-click="generateDebugQset()">Generate QSet</button>
-			<button type="button" class="temp-qset-gen-button" ng-click="showQsetLoader = true">Load QSet</button>
 			<!-- <button type="button" class="temp-qset-gen-button" ng-click="onSaveClicked('publish')">Simulate Publish</button> -->
 		</header>
 		<div id="adventure-container">
@@ -719,7 +716,6 @@
 					<img src="assets/creator-assets/drawer-arrow.svg" />
 					Action History
 				</header>
-				<!-- <div ng-click="dumpHistory()">Dump History</div> -->
 				<div class="action-history" ng-repeat="item in treeHistoryItems | orderBy: '-timestamp'" ng-click="rollBackToSnapshot(item.index)">
 					{{item.context}}
 				</div>

--- a/src/creator.html
+++ b/src/creator.html
@@ -712,7 +712,7 @@
 			</div>
 			<tree-history ng-class="{ 'minimized':minimized }">
 				<header ng-click="minimized = !minimized">Action History</header>
-				<div ng-click="dumpHistory()">Dump History</div>
+				<!-- <div ng-click="dumpHistory()">Dump History</div> -->
 				<div ng-repeat="item in treeHistoryItems | orderBy: '-timestamp'" ng-click="rollBackToSnapshot(item.index)">
 					{{item.context}}
 				</div>

--- a/src/creator.html
+++ b/src/creator.html
@@ -41,8 +41,8 @@
 				<button type="button" class="header-options-button" ng-click="showScoreModeDialog = true; showBackgroundCover = true">{{scoreMode}}</button>
 			</div>
 
-			<!-- <button type="button" class="temp-qset-gen-button" ng-click="generateDebugQset()">Generate QSet</button>
-			<button type="button" class="temp-qset-gen-button" ng-click="showQsetLoader = true">Load QSet</button> -->
+			<button type="button" class="temp-qset-gen-button" ng-click="generateDebugQset()">Generate QSet</button>
+			<button type="button" class="temp-qset-gen-button" ng-click="showQsetLoader = true">Load QSet</button>
 			<!-- <button type="button" class="temp-qset-gen-button" ng-click="onSaveClicked('publish')">Simulate Publish</button> -->
 		</header>
 		<div id="adventure-container">
@@ -710,6 +710,13 @@
 						ng-click="hideCoverAndModals()">Done</button>
 				</div>
 			</div>
+			<tree-history ng-class="{ 'minimized':minimized }">
+				<header ng-click="minimized = !minimized">Action History</header>
+				<div ng-click="dumpHistory()">Dump History</div>
+				<div ng-repeat="item in treeHistoryItems | orderBy: '-timestamp'" ng-click="rollBackToSnapshot(item.index)">
+					{{item.context}}
+				</div>
+			</tree-history>
 			<div id="backgroundcover" ng-click="hideCoverAndModals()" ng-class="{ show: showBackgroundCover }"></div>
 			<tree-visualization data="treeData"
 				offset="treeOffset"

--- a/src/creator.html
+++ b/src/creator.html
@@ -715,7 +715,10 @@
 					<button ng-click="undoAction()" ng-disabled="historyPosition <= 0">Undo</button>
 					<button ng-click="redoAction()" ng-disabled="historyPosition >= historySize-1">Redo</button>
 				</div>
-				<header ng-click="minimized = !minimized">Action History</header>
+				<header ng-click="minimized = !minimized">
+					<img src="assets/creator-assets/drawer-arrow.svg" />
+					Action History
+				</header>
 				<!-- <div ng-click="dumpHistory()">Dump History</div> -->
 				<div class="action-history" ng-repeat="item in treeHistoryItems | orderBy: '-timestamp'" ng-click="rollBackToSnapshot(item.index)">
 					{{item.context}}

--- a/src/src-assets/creator-assets/controllers.coffee
+++ b/src/src-assets/creator-assets/controllers.coffee
@@ -166,6 +166,8 @@ Adventure.controller "AdventureCtrl", ['$scope', '$filter', '$compile', '$rootSc
 
 			# Redraw tree (again) to address any post-edit changes
 			treeSrv.set $scope.treeData
+			
+			if $scope.editedNode then treeHistorySrv.addToHistory $scope.treeData, historyActions.NODE_EDITED, "Destination " + $scope.integerToLetters($scope.editedNode.id) + " edited"
 
 
 	$scope.hideCoverAndModals = ->
@@ -351,8 +353,6 @@ Adventure.controller "AdventureCtrl", ['$scope', '$filter', '$compile', '$rootSc
 	# Function that explicitly adds a node between an existing parent and child
 	$scope.addNodeInBetween = (data) ->
 
-		treeHistorySrv.addToHistory $scope.treeData, historyActions.NODE_ADDED_IN_BETWEEN, "Destination created between " + treeSrv.integerToLetters(data.source) + " and " + treeSrv.integerToLetters(data.target)
-
 		newId = treeSrv.getNodeCount()
 		newName = treeSrv.integerToLetters newId
 
@@ -374,6 +374,9 @@ Adventure.controller "AdventureCtrl", ['$scope', '$filter', '$compile', '$rootSc
 		treeSrv.set $scope.treeData
 
 		treeSrv.updateAllAnswerLinks $scope.treeData
+
+		treeHistorySrv.addToHistory $scope.treeData, historyActions.NODE_ADDED_IN_BETWEEN, "Destination created between " + treeSrv.integerToLetters(data.source) + " and " + treeSrv.integerToLetters(data.target)
+
 
 	# Reference function so the integerToLetters function from treeSrv can be called using two-way data binding
 	$scope.integerToLetters = (val) ->

--- a/src/src-assets/creator-assets/controllers.coffee
+++ b/src/src-assets/creator-assets/controllers.coffee
@@ -223,6 +223,8 @@ Adventure.controller "AdventureCtrl", ['$scope', '$filter', '$compile', '$rootSc
 				treeSrv.set $scope.treeData
 				treeSrv.updateAllAnswerLinks $scope.treeData
 
+				treeHistorySrv.addToHistory $scope.treeData, historyActions.EXISTING_WIDGET_INIT, "Existing Widget Initialized"
+
 	materiaCallbacks.onSaveClicked = (mode = 'save') ->
 		if mode is "publish" then validation = treeSrv.validateTreeOnSave $scope.treeData
 		else validation = []

--- a/src/src-assets/creator-assets/controllers.coffee
+++ b/src/src-assets/creator-assets/controllers.coffee
@@ -196,6 +196,8 @@ Adventure.controller "AdventureCtrl", ['$scope', '$filter', '$compile', '$rootSc
 			$scope.showIntroDialog = true
 			$scope.showBackgroundCover = true
 
+			treeHistorySrv.addToHistory $scope.treeData, historyActions.WIDGET_INIT, "Widget Initialized"
+
 	materiaCallbacks.initExistingWidget = (title,widget,qset,version,baseUrl) ->
 
 		showIntroDialog = false

--- a/src/src-assets/creator-assets/controllers.coffee
+++ b/src/src-assets/creator-assets/controllers.coffee
@@ -166,8 +166,15 @@ Adventure.controller "AdventureCtrl", ['$scope', '$filter', '$compile', '$rootSc
 
 			# Redraw tree (again) to address any post-edit changes
 			treeSrv.set $scope.treeData
-			
-			if $scope.editedNode then treeHistorySrv.addToHistory $scope.treeData, historyActions.NODE_EDITED, "Destination " + $scope.integerToLetters($scope.editedNode.id) + " edited"
+						
+			# prevents polluting the action history by comparing the current tree to to the latest snapshot
+			# only add the current tree as a snapshot if the tree was actually edited
+			if $scope.editedNode
+				lastIndex = treeHistorySrv.getHistorySize() - 1
+				if lastIndex is -1 then treeHistorySrv.addToHistory $scope.treeData, historyActions.NODE_EDITED, "Destination " + $scope.integerToLetters($scope.editedNode.id) + " edited"
+				else
+					peek = treeHistorySrv.retrieveSnapshot(lastIndex)
+					unless treeHistorySrv.compareTrees(peek.tree, $scope.treeData) then treeHistorySrv.addToHistory $scope.treeData, historyActions.NODE_EDITED, "Destination " + $scope.integerToLetters($scope.editedNode.id) + " edited"
 
 
 	$scope.hideCoverAndModals = ->

--- a/src/src-assets/creator-assets/controllers.coffee
+++ b/src/src-assets/creator-assets/controllers.coffee
@@ -1,5 +1,5 @@
 Adventure = angular.module "Adventure"
-Adventure.controller "AdventureCtrl", ['$scope', '$filter', '$compile', '$rootScope', '$timeout', '$sanitize', 'treeSrv', 'legacyQsetSrv',($scope, $filter, $compile, $rootScope, $timeout, $sanitize, treeSrv, legacyQsetSrv) ->
+Adventure.controller "AdventureCtrl", ['$scope', '$filter', '$compile', '$rootScope', '$timeout', '$sanitize', 'treeSrv', 'treeHistorySrv', 'legacyQsetSrv',($scope, $filter, $compile, $rootScope, $timeout, $sanitize, treeSrv, treeHistorySrv, legacyQsetSrv) ->
 	materiaCallbacks = {}
 
 	# Define constants for node screen types
@@ -100,6 +100,8 @@ Adventure.controller "AdventureCtrl", ['$scope', '$filter', '$compile', '$rootSc
 	$scope.validation =
 		show: false
 		errors: []
+
+	historyActions = treeHistorySrv.getActions()
 
 	$scope.$watch "displayNodeCreation", (newVal, oldVal) ->
 
@@ -348,6 +350,8 @@ Adventure.controller "AdventureCtrl", ['$scope', '$filter', '$compile', '$rootSc
 
 	# Function that explicitly adds a node between an existing parent and child
 	$scope.addNodeInBetween = (data) ->
+
+		treeHistorySrv.addToHistory $scope.treeData, historyActions.NODE_ADDED_IN_BETWEEN, "Destination created between " + treeSrv.integerToLetters(data.source) + " and " + treeSrv.integerToLetters(data.target)
 
 		newId = treeSrv.getNodeCount()
 		newName = treeSrv.integerToLetters newId

--- a/src/src-assets/creator-assets/creator.scss
+++ b/src/src-assets/creator-assets/creator.scss
@@ -260,7 +260,7 @@ header.title-header {
 	overflow-y: hidden;
 	// overflow-y: auto;
 
-	// border-bottom: solid 5px $color-accent;
+	border-bottom: solid 1px $gray-lighter;
 }
 
 /* Tree Visualization Styles */

--- a/src/src-assets/creator-assets/creator.scss
+++ b/src/src-assets/creator-assets/creator.scss
@@ -854,7 +854,6 @@ tree-history {
 
 	header {
 		display: block;
-		margin-bottom: 1px;
 		padding-top: 5px;
 		padding-bottom: 5px;
 		font-size: 1.1em;
@@ -869,6 +868,7 @@ tree-history {
 
 		border-top-left-radius: 3px;
 		border-top-right-radius: 3px;
+		border-bottom: solid 1px $white;
 	}
 
 	div {

--- a/src/src-assets/creator-assets/creator.scss
+++ b/src/src-assets/creator-assets/creator.scss
@@ -835,6 +835,58 @@ title-editor {
 	}
 }
 
+tree-history {
+	position: absolute;
+	right: 5px;
+	bottom: 0px;
+	z-index: 10;
+
+	width: 240px;
+	font-size: 0.8em;
+
+	text-align: center;
+
+	// border: solid 1px $gray-darker
+
+	&.minimized {
+		top: calc(100% - 25px);
+	}
+
+	header {
+		display: block;
+		margin-bottom: 1px;
+		padding-top: 5px;
+		padding-bottom: 5px;
+		font-size: 1.1em;
+		font-weight: bold;
+		
+		background: $color-accent;
+		color: $white;
+
+		user-select: none;
+
+		cursor: pointer;
+
+		border-top-left-radius: 3px;
+		border-top-right-radius: 3px;
+	}
+
+	div {
+		width: 240px;
+		min-height: 10px;
+
+		padding: 3px 0px 3px 0px;
+
+		background: $white;
+
+		&:hover {
+			background: $color-accent;
+			color: #ffffff;
+			transition: background 500ms;
+			cursor: pointer;
+		}
+	}
+}
 
 node-tools-dialog {
 	position: absolute;

--- a/src/src-assets/creator-assets/creator.scss
+++ b/src/src-assets/creator-assets/creator.scss
@@ -50,6 +50,15 @@ $edit-popup-less-height: 600px;
 $edit-popup-standard-height: 620px;
 // $edit-popup-extra-height: 620px;
 // $edit-popup-less-height: 570px;
+ 
+$z-index-default: 0;
+$z-index-behind-cover: 5;
+$z-index-background-cover: 10;
+$z-index-modal-low-priority: 25;
+$z-index-modal: 50;
+$z-index-modal-svg: 75;
+$z-index-modal-dialog: 100;
+$z-index-very-important: 1000;
 
 html, body {
 	height: 100%;
@@ -101,7 +110,7 @@ div.fancy-toggle {
 	&:after {
 		position: absolute;
 		right: 10px;
-		z-index: 0;
+		z-index: $z-index-default;
 
 		content: 'OFF';
 
@@ -113,7 +122,7 @@ div.fancy-toggle {
 	&:before {
 		position: absolute;
 		left: 10px;
-		z-index: 0;
+		z-index: $z-index-default;
 
 		content: 'ON';
 
@@ -126,7 +135,7 @@ div.fancy-toggle {
 		position: absolute;
 		top: 3px;
 		left: 3px;
-		z-index: 1;
+		z-index: $z-index-behind-cover;
 
 		display: block;
 		width: 34px;
@@ -165,7 +174,6 @@ div.fancy-toggle {
 
 #backgroundcover {
 	position: fixed;
-	z-index: 1;
 	top: 0px;
 	right: 0px;
 	bottom: 0px;
@@ -175,7 +183,7 @@ div.fancy-toggle {
 	opacity: 0;
 	transition: all 0.5s ease;
 	&.show {
-		z-index: 1;
+		z-index: $z-index-background-cover;
 		opacity: 0.3;
 		transition: opacity 0.5s ease;
 	}
@@ -470,6 +478,7 @@ button {
 
 		&:disabled {
 			color: $gray-lighter;
+			cursor: auto;
 		}
 	}
 
@@ -567,7 +576,7 @@ debug-qset-loader, debug-qset-generator {
 	margin-left: -175px;
 	padding-bottom: 25px;
 
-	z-index: 5;
+	z-index: $z-index-modal;
 
 	background: $color-primary;
 	border-radius: 5px;
@@ -610,7 +619,8 @@ debug-qset-loader, debug-qset-generator {
 	width: 620px;
 	top: 10%;
 	left: 50%;
-	z-index: 2;
+	z-index: $z-index-modal;
+
 	margin-left: -325px;
 
 	padding: 15px 15px 25px 20px;
@@ -661,7 +671,7 @@ debug-qset-loader, debug-qset-generator {
 	width: 620px;
 	top: 10%;
 	left: 50%;
-	z-index: 2;
+	z-index: $z-index-modal;
 	margin-left: -325px;
 
 	// padding: 15px 15px 25px 20px;
@@ -738,7 +748,7 @@ debug-qset-loader, debug-qset-generator {
 
 toast {
 	position: absolute;
-	z-index: 90;
+	z-index: $z-index-very-important;
 
 	width: 600px;
 	min-height: 30px;
@@ -808,7 +818,7 @@ title-editor {
 	margin-left: -200px;
 	padding-bottom: 25px;
 
-	z-index: 5;
+	z-index: $z-index-modal;
 
 	background: $color-primary;
 	border-radius: 5px;
@@ -843,7 +853,7 @@ tree-history {
 	position: absolute;
 	right: 5px;
 	bottom: 0px;
-	z-index: 10;
+	z-index: $z-index-behind-cover;
 
 	width: 240px;
 	font-size: 0.8em;
@@ -854,6 +864,11 @@ tree-history {
 
 	&.minimized {
 		top: calc(100% - 55px);
+
+		header img {
+			top: 5px;
+			transform: rotate(180deg);
+		}
 	}
 
 	div.undo-redo-options {
@@ -879,6 +894,7 @@ tree-history {
 	}
 
 	header {
+		position: relative;
 		display: block;
 		padding-top: 3px;
 		padding-bottom: 5px;
@@ -895,6 +911,21 @@ tree-history {
 		border-top-left-radius: 3px;
 		border-top-right-radius: 3px;
 		border-bottom: solid 1px $white;
+
+		&:hover {
+			background: $color-accent-highlight;
+		}
+
+		img {
+			position: absolute;
+			top: 8px;
+			left: 10px;
+			width: 12px;
+			height: 12px;
+
+			transform: rotate(0deg);
+			transition: 250ms all;
+		}
 	}
 
 	div.action-history {
@@ -916,7 +947,7 @@ tree-history {
 
 node-tools-dialog {
 	position: absolute;
-	z-index: 30;
+	z-index: $z-index-modal-low-priority;
 
 	width: 200px;
 	// height: 85px;
@@ -967,7 +998,7 @@ node-tools-dialog {
 
 new-node-manager-dialog {
 	position: fixed;
-	z-index: 1000;
+	z-index: $z-index-very-important;
 	width: 400px;
 	height: 150px;
 
@@ -1029,7 +1060,7 @@ delete-warning-dialog {
 	position: fixed;
 	width: 300px;
 
-	z-index: 1050;
+	z-index: $z-index-very-important;
 
 	background: $color-primary;
 
@@ -1067,7 +1098,7 @@ node-creation-selection-dialog {
 	// position: absolute;
 	position: fixed;
 	left: 50%;
-	z-index: 40;
+	z-index: $z-index-modal;
 
 	width: $misc-popup-width;
 	height: $edit-popup-less-height;
@@ -1225,7 +1256,7 @@ node-creation-selection-dialog {
 	// position: absolute;
 	position: fixed;
 	left: 50%;
-	z-index: 50;
+	z-index: $z-index-modal;
 
 	width: $edit-popup-width;
 	height: $edit-popup-less-height - 30;
@@ -1350,7 +1381,7 @@ node-creation-selection-dialog {
 
 				&:focus {
 					position: absolute;
-					z-index: 150;
+					z-index: $z-index-modal;
 					height: 50px;
 				}
 			}
@@ -1732,7 +1763,7 @@ node-creation-selection-dialog {
 
 			svg#hotspot-canvas {
 				position: absolute;
-				z-index: 100;
+				z-index: $z-index-modal-svg;
 
 				top: 0px;
 				left: 0px;
@@ -1775,7 +1806,7 @@ node-creation-selection-dialog {
 			img {
 				position: relative;
 
-				z-index: 60;
+				z-index: $z-index-modal + 1;
 				max-width: 100%;
 				max-height: 100%;
 			}
@@ -1817,7 +1848,7 @@ node-creation-selection-dialog {
 			margin-left: -150px;
 			bottom: 40px;
 
-			z-index: 160;
+			z-index: $z-index-modal-dialog;
 
 			background: $color-primary;
 
@@ -1870,7 +1901,7 @@ node-creation-selection-dialog {
 			display: none;
 			width: 0px;
 
-			z-index: 150;
+			z-index: $z-index-modal-dialog;
 
 			padding-bottom: 52px;
 
@@ -2043,7 +2074,7 @@ node-creation-selection-dialog {
 			position: absolute;
 			width: 698px;
 			height: 400px;
-			z-index: 200;
+			z-index: $z-index-modal-svg + 1;
 
 			background: $white;
 			opacity: 0.7;
@@ -2054,7 +2085,7 @@ node-creation-selection-dialog {
 validation-dialog {
 	position: fixed;
 	left: 50%;
-	z-index: 60;
+	z-index: $z-index-modal;
 
 	width: $misc-popup-width;
 	// height: 600px;

--- a/src/src-assets/creator-assets/creator.scss
+++ b/src/src-assets/creator-assets/creator.scss
@@ -910,7 +910,7 @@ tree-history {
 
 		border-top-left-radius: 3px;
 		border-top-right-radius: 3px;
-		border-bottom: solid 1px $white;
+		// border-bottom: solid 1px $white;
 
 		&:hover {
 			background: $color-accent-highlight;
@@ -918,10 +918,10 @@ tree-history {
 
 		img {
 			position: absolute;
-			top: 8px;
+			top: 11px;
 			left: 10px;
-			width: 12px;
-			height: 12px;
+			width: 9px;
+			height: 9px;
 
 			transform: rotate(0deg);
 			transition: 250ms all;
@@ -929,12 +929,15 @@ tree-history {
 	}
 
 	div.action-history {
-		width: 240px;
+		width: 238px;
 		min-height: 10px;
 
 		padding: 3px 0px 3px 0px;
 
 		background: $white;
+
+		border-left: solid 1px $gray-lighter;
+		border-right: solid 1px $gray-lighter;
 
 		&:hover {
 			background: $color-accent;

--- a/src/src-assets/creator-assets/creator.scss
+++ b/src/src-assets/creator-assets/creator.scss
@@ -467,6 +467,10 @@ button {
 
 	&:hover {
 		color: $color-accent;
+
+		&:disabled {
+			color: $gray-lighter;
+		}
 	}
 
 	&.delete-button {
@@ -849,15 +853,37 @@ tree-history {
 	// border: solid 1px $gray-darker
 
 	&.minimized {
-		top: calc(100% - 25px);
+		top: calc(100% - 55px);
+	}
+
+	div.undo-redo-options {
+		position: relative;
+		top: 0px;
+		width: 100%;
+		margin-bottom: 5px;
+
+		button {
+			width: 40%;
+			font-size:1.1em;
+			// background: $color-accent;
+			// color: $white;
+
+			@include user-select-none();
+
+			cursor: pointer;
+
+			&:first-child {
+				margin-right: 5%;
+			}
+		}
 	}
 
 	header {
 		display: block;
-		padding-top: 5px;
+		padding-top: 3px;
 		padding-bottom: 5px;
-		font-size: 1.1em;
-		font-weight: bold;
+		// font-size: 1.1em;
+		// font-weight: bold;
 		
 		background: $color-accent;
 		color: $white;
@@ -871,7 +897,7 @@ tree-history {
 		border-bottom: solid 1px $white;
 	}
 
-	div {
+	div.action-history {
 		width: 240px;
 		min-height: 10px;
 

--- a/src/src-assets/creator-assets/directives.coffee
+++ b/src/src-assets/creator-assets/directives.coffee
@@ -1046,12 +1046,6 @@ Adventure.directive "nodeToolsDialog", ['treeSrv', 'treeHistorySrv','$rootScope'
 			# Toast is displayed until clicked or until the node creation screen is closed
 			$scope.toast "Destination " + $scope.integerToLetters(target.id) + " has been reset."
 
-			# Cancel out the toast after 8 seconds, enough time for someone to decide they made a mistake hopefully
-			# if $scope.toastRegister isnt null then $timeout.cancel $scope.toastRegister
-			# $scope.toastRegister = $timeout (() ->
-			# 	$scope.hideToast()
-			# ), 8000
-
 			$scope.nodeTools.showResetWarning = false
 			$scope.nodeTools.show = false
 			$scope.nodeTools.target = null
@@ -1101,12 +1095,6 @@ Adventure.directive "nodeToolsDialog", ['treeSrv', 'treeHistorySrv','$rootScope'
 			$scope.toast "Destination " + $scope.integerToLetters(target.id) + " was deleted."
 
 			treeHistorySrv.addToHistory $scope.treeData, historyActions.NODE_DELETED, "Destination " + $scope.integerToLetters(target.id) + " deleted"
-
-			# Cancel out the toast after 8 seconds, enough time for someone to decide they made a mistake hopefully
-			# if $scope.toastRegister isnt null then $timeout.cancel $scope.toastRegister
-			# $scope.toastRegister = $timeout (() ->
-			# 	$scope.hideToast()
-			# ), 8000
 
 			$scope.nodeTools.showDeleteWarning = false
 			$scope.nodeTools.show = false

--- a/src/src-assets/creator-assets/directives.coffee
+++ b/src/src-assets/creator-assets/directives.coffee
@@ -735,6 +735,8 @@ Adventure.directive "nodeTooltips", ['treeSrv', (treeSrv) ->
 				$scope.hoveredNode.showTooltips = true
 ]
 
+# Directive in charge of managing the Action History, in conjunction with the treeHistorySrv service
+# for more information see the comment for treeHistorySrv in services
 Adventure.directive "treeHistory", ['treeSrv','treeHistorySrv', '$rootScope', (treeSrv, treeHistorySrv, $rootScope) ->
 	restrict: "E",
 	link: ($scope, $element, $attrs) ->
@@ -743,9 +745,12 @@ Adventure.directive "treeHistory", ['treeSrv','treeHistorySrv', '$rootScope', (t
 
 		$scope.minimized = true
 
-		$scope.historyPosition = -1
+		$scope.historyPosition = -1 # this is the history "cursor". By default it's updated to point to the top-most action, but changes with undo/redo actions or selecting an earlier action
 		$scope.historySize = 0
 
+		# the history stack is evaluated every time a new history action is added
+		# if the history "cursor" is not at the top of the stack (they've clicked undo or have selected an earlier action),
+		# and a new action is performed, all actions between the cursor and the top of the stack are discarded
 		$scope.$on "tree.history.added", (evt) ->
 			
 			# Have to get initial size of history stack
@@ -786,10 +791,6 @@ Adventure.directive "treeHistory", ['treeSrv','treeHistorySrv', '$rootScope', (t
 			treeSrv.setNodeCount snapshot.nodeCount
 
 			$scope.historyPosition = index
-
-		$scope.dumpHistory = () ->
-			console.log treeHistorySrv.getHistory()
-		]
 
 
 # Directive for the node modal dialog (edit the node, copy the node, reset the node, etc)

--- a/src/src-assets/creator-assets/directives.coffee
+++ b/src/src-assets/creator-assets/directives.coffee
@@ -1307,9 +1307,6 @@ Adventure.directive "newNodeManagerDialog", ['treeSrv', 'treeHistorySrv', '$docu
 								$scope.existingNodeSelectionMode = true
 								return
 
-							# Deep copy the original answer in case undo is needed
-							# removedNodeAnswer = angular.copy $scope.answers[i]
-
 							# Set the answer's new target to the newly selected node
 							$scope.answers[i].target = newVal.id
 
@@ -1320,7 +1317,6 @@ Adventure.directive "newNodeManagerDialog", ['treeSrv', 'treeHistorySrv', '$docu
 								childNode = treeSrv.findNode $scope.treeData, $scope.newNodeManager.target
 
 								if childNode
-									# if childNode.type isnt $scope.BLANK
 									removedNodeId = childNode.id
 
 									removed = treeSrv.findAndRemove $scope.treeData, childNode.id
@@ -1352,7 +1348,6 @@ Adventure.directive "newNodeManagerDialog", ['treeSrv', 'treeHistorySrv', '$docu
 							# Cancel out the answer tooltip, or it persists
 							$scope.hoveredNode.showTooltips = false
 							$scope.hoveredNode.target = null
-							# $scope.hoveredNode.targetParent = null
 
 							$scope.existingNodeSelected = null
 							$scope.newNodeManager.target = null
@@ -2268,7 +2263,7 @@ Adventure.directive "validationDialog", ['treeSrv','$rootScope', (treeSrv, $root
 
 
 # MEANT FOR DEBUG PURPOSES ONLY
-Adventure.directive "debugQsetLoader", ['treeSrv','legacyQsetSrv','$rootScope', (treeSrv, legacyQsetSrv, $rootScope) ->
+Adventure.directive "debugQsetLoader", ['treeSrv', 'treeHistorySrv', 'legacyQsetSrv','$rootScope', (treeSrv, treeHistorySrv, legacyQsetSrv, $rootScope) ->
 	restrict: "E",
 	link: ($scope, $element, $attrs) ->
 
@@ -2303,6 +2298,9 @@ Adventure.directive "debugQsetLoader", ['treeSrv','legacyQsetSrv','$rootScope', 
 			treeSrv.set $scope.treeData
 			treeSrv.updateAllAnswerLinks $scope.treeData
 			$scope.showQsetLoader = false
+
+			historyActions = treeHistorySrv.getActions()
+			treeHistorySrv.addToHistory $scope.treeData, historyActions.EXISTING_WIDGET_INIT, "Existing Widget Initialized"
 ]
 
 

--- a/src/src-assets/creator-assets/directives.coffee
+++ b/src/src-assets/creator-assets/directives.coffee
@@ -80,7 +80,7 @@ Adventure.directive "treeVisualization", ['treeSrv', '$window', '$compile', '$ro
 		$scope.copyMode = false
 
 		$scope.windowWidth = document.getElementById("adventure-container").offsetWidth - 15
-		$scope.windowHeight = document.getElementById("adventure-container").offsetHeight - 60
+		$scope.windowHeight = document.getElementById("adventure-container").offsetHeight
 		$scope.treeContainerWidth = null
 
 		# Re-render tree whenever the nodes are updated

--- a/src/src-assets/creator-assets/directives.coffee
+++ b/src/src-assets/creator-assets/directives.coffee
@@ -752,7 +752,7 @@ Adventure.directive "treeHistory", ['treeSrv','treeHistorySrv', '$rootScope', (t
 
 		$scope.rollBackToSnapshot = (index) ->
 			snapshot = treeHistorySrv.retrieveSnapshot index
-			tree = JSON.parse snapshot.tree
+			tree = treeSrv.createTreeDataFromQset JSON.parse snapshot.tree
 			$scope.treeData = tree
 			treeSrv.set tree
 			treeSrv.setNodeCount snapshot.nodeCount
@@ -881,13 +881,13 @@ Adventure.directive "nodeToolsDialog", ['treeSrv', 'treeHistorySrv','$rootScope'
 						# Update the original tree target with the copy
 						result = treeSrv.findAndReplace $scope.treeData, targetNode.id, copyTree
 
+						# Snapshot the tree
+						treeHistorySrv.addToHistory $scope.treeData, historyActions.NODE_COPIED, "Destination " + $scope.integerToLetters($scope.nodeTools.target) + " copied to " + $scope.integerToLetters(targetNode.id)
+
 					deregister()
 
 					# Update the tree
 					treeSrv.set $scope.treeData
-
-					# Snapshot the tree
-					treeHistorySrv.addToHistory $scope.treeData, historyActions.NODE_COPIED, "Destination " + $scope.integerToLetters($scope.nodeTools.target) + " copied"
 
 					# Reset all values
 					$scope.copyNodeTarget = null

--- a/src/src-assets/creator-assets/directives.coffee
+++ b/src/src-assets/creator-assets/directives.coffee
@@ -791,6 +791,7 @@ Adventure.directive "treeHistory", ['treeSrv','treeHistorySrv', '$rootScope', (t
 			treeSrv.setNodeCount snapshot.nodeCount
 
 			$scope.historyPosition = index
+]
 
 
 # Directive for the node modal dialog (edit the node, copy the node, reset the node, etc)

--- a/src/src-assets/creator-assets/services.coffee
+++ b/src/src-assets/creator-assets/services.coffee
@@ -745,6 +745,7 @@ Adventure.service "treeHistorySrv", ['treeSrv', '$rootScope', (treeSrv, $rootSco
 
 	history = []
 	actions =
+		WIDGET_INIT: "WIDGET_INIT"
 		EXISTING_WIDGET_INIT: "EXISTING_WIDGET_INIT"
 		NODE_RESET: "NODE_RESET"
 		NODE_DELETED: "NODE_DELETED"
@@ -777,7 +778,7 @@ Adventure.service "treeHistorySrv", ['treeSrv', '$rootScope', (treeSrv, $rootSco
 		snapshot = createSnapshot tree, action, context
 		history.push snapshot
 
-		if history.length > HISTORY_LIMIT then history.splice HISTORY_LIMIT, 1
+		if history.length > HISTORY_LIMIT then history.splice 0, 1
 		$rootScope.$broadcast "tree.history.added"
 
 	spliceHistory = (index, distance = 1) ->

--- a/src/src-assets/creator-assets/services.coffee
+++ b/src/src-assets/creator-assets/services.coffee
@@ -778,11 +778,11 @@ Adventure.service "treeHistorySrv", ['treeSrv', '$rootScope', (treeSrv, $rootSco
 		history.push snapshot
 
 		if history.length > HISTORY_LIMIT then history.splice HISTORY_LIMIT, 1
-		$rootScope.$broadcast "tree.history.updated"
+		$rootScope.$broadcast "tree.history.added"
 
-	removeFromHistory = (index) ->
-		history.splice(index, 1)
-		$rootScope.$broadcast "tree.history.updated"
+	spliceHistory = (index, distance = 1) ->
+		history.splice(index, distance)
+		$rootScope.$broadcast "tree.history.removed"
 
 	retrieveSnapshot = (index) ->
 		return history[index]
@@ -799,7 +799,7 @@ Adventure.service "treeHistorySrv", ['treeSrv', '$rootScope', (treeSrv, $rootSco
 	getHistorySize : getHistorySize
 	createSnapshot : createSnapshot
 	addToHistory : addToHistory
-	removeFromHistory : removeFromHistory
+	spliceHistory : spliceHistory
 	retrieveSnapshot : retrieveSnapshot
 	compareTrees : compareTrees
 ]

--- a/src/src-assets/creator-assets/services.coffee
+++ b/src/src-assets/creator-assets/services.coffee
@@ -745,6 +745,7 @@ Adventure.service "treeHistorySrv", ['treeSrv', '$rootScope', (treeSrv, $rootSco
 
 	history = []
 	actions =
+		EXISTING_WIDGET_INIT: "EXISTING_WIDGET_INIT"
 		NODE_RESET: "NODE_RESET"
 		NODE_DELETED: "NODE_DELETED"
 		NODE_ANSWER_REMOVED: "NODE_ANSWER_REMOVED"

--- a/src/src-assets/creator-assets/services.coffee
+++ b/src/src-assets/creator-assets/services.coffee
@@ -739,6 +739,11 @@ Adventure.service "treeSrv", ['$rootScope','$filter','$sanitize','legacyQsetSrv'
 	generateAnswerHash : generateAnswerHash
 ]
 
+# The service in charge of managing Action History, replacing the clunky "deleteAndRestoreSrv" service
+# The history array contains entire snapshots of the tree, up to the limit determined by HISTORY_LIMIT
+# action constants have no direct application currently, but are implemented for potential future features
+# various user actions result in addToHistory being called to store the tree AFTER the action has been performed, with some contextual information
+# note that the action history is not stored to the qset and is lost if the creator is reloaded or upon exit
 Adventure.service "treeHistorySrv", ['treeSrv', '$rootScope', (treeSrv, $rootScope) ->
 
 	HISTORY_LIMIT = 20
@@ -778,7 +783,7 @@ Adventure.service "treeHistorySrv", ['treeSrv', '$rootScope', (treeSrv, $rootSco
 		snapshot = createSnapshot tree, action, context
 		history.push snapshot
 
-		if history.length > HISTORY_LIMIT then history.splice 0, 1
+		if history.length > HISTORY_LIMIT then history.splice 0, 1 # not using spliceHistory here to avoid broadcasting tree.history.removed
 		$rootScope.$broadcast "tree.history.added"
 
 	spliceHistory = (index, distance = 1) ->

--- a/src/src-assets/creator-assets/services.coffee
+++ b/src/src-assets/creator-assets/services.coffee
@@ -300,7 +300,6 @@ Adventure.service "treeSrv", ['$rootScope','$filter','$sanitize','legacyQsetSrv'
 						parentId: tree.id
 						type: "blank"
 						contents: []
-						replacementForTarget: targetId # This flag allows deleteAndRestoreSrv to identify this node as a replacement for an existing link whose target was removed
 
 					# Update the answer too
 					answer.target = newId
@@ -740,240 +739,52 @@ Adventure.service "treeSrv", ['$rootScope','$filter','$sanitize','legacyQsetSrv'
 	generateAnswerHash : generateAnswerHash
 ]
 
-# Handles the storage of deleted nodes in a global "cryo cache", where they can be restored at a later time
-# Currently, they can only be restored immediately after deletion, during the window of the undo prompt
-# I believe this solution is entirely over-engineered; rather than storing individual nodes, all their associated state information, AND implementing logic to restore them,
-# it is probably better to simply snapshot the entire tree pre-deletion, and allow the tree to simply "roll back" to the prior state if the undo option is selected.
-Adventure.service "deleteAndRestoreSrv", ['$rootScope','treeSrv', ($rootScope, treeSrv) ->
+Adventure.service "treeHistorySrv", ['treeSrv', '$rootScope', (treeSrv, $rootScope) ->
+
+	history = []
+	actions =
+		NODE_RESET: "NODE_RESET"
+		NODE_DELETED: "NODE_DELETED"
+		NODE_ANSWER_REMOVED: "NODE_ANSWER_REMOVED"
+		NODE_PARENT_REMOVED: "NODE_PARENT_REMOVED"
+		NODE_REPLACED_WITH_EXISTING: "NODE_REPLACED_WITH_EXISTING"
+
+	getActions = () ->
+		return actions
+
+	getHistory = () ->
+		return history
+
+	createSnapshot = (tree, action, context) ->
+		snapshot =
+			action : action
+			context: context ? context : ""
+			timestamp : Date.now()
+			tree: JSON.stringify(tree)
+
+	addToHistory = (tree, action, context) ->
+		snapshot = createSnapshot tree, action, context
+		history.push snapshot
+		$rootScope.$broadcast "tree.history.updated"
+
+	removeFromHistory = (index) ->
+		history.splice(index, 1)
+		$rootScope.$broadcast "tree.history.updated"
+
+	applySnapshot = (index) ->
+		snappedTree = JSON.parse history[index].tree
+		treeSrv.set snappedTree
+		
+		if history.length > 10 then history.splice 10, 1
+		
+		return snappedTree
+
+
+	getActions : getActions
+	getHistory : getHistory
+	createSnapshot : createSnapshot
+	addToHistory : addToHistory
+	removeFromHistory : removeFromHistory
+	applySnapshot : applySnapshot
 
-	cache = []
-
-	get = () ->
-		return cache
-
-	set = (existing) ->
-		cache = existing
-
-	add = (item) ->
-		cache[item.id] = item
-
-	# Builds a "cold storage" object for deleted nodes. These are added to the global cryo cache for future restoration
-	# Cold storage objects include references to their associated answer, their original answer index, and a deep copy of the node itself
-	# Aside from the node itself, all params are optional, allowing them to be overridden for special use cases
-	coldStorage = (node, nodeIndex = null, parent = null, answer = null, answerIndex = null) ->
-
-		tree = treeSrv.get()
-
-		# If any of the optional params are null, have to grab defaults
-		if parent is null then parent = treeSrv.findNode tree, node.parentId
-
-		# Find reference to node in parent's answers
-		if answerIndex is null
-			angular.forEach parent.answers, (answer, index) ->
-				if answer.target is node.id and answer.linkMode is "new"
-					answerIndex = index
-
-		if answer is null
-			answer = if parent.answers then parent.answers[answerIndex] else {} # handle exception case where parent is blank
-		if nodeIndex is null then nodeIndex = parent.contents.indexOf node # node index may differ from answer index due to answers with non-traditional links
-
-		cacheExistingLinks node
-
-		# Prep node as a coldStorage object
-		cryo =
-			id: node.id
-			answerIndex: answerIndex
-			answer: answer
-			node: angular.copy node # have to make a deep copy of the node to prevent it being skewered by changes elsewhere
-			nodeIndex: nodeIndex
-
-		# Did we delete the child of a blank node? Make sure we add a flag in the cryo object to restore it
-		if parent.pendingTarget and parent.pendingTarget is node.id then cryo.parentHasPendingTarget = true
-
-		# Add to the global cryo cache
-		add cryo
-
-	# Node deletion occurs in two places: by deleting its associated answer in the editor of the node's hierarchical parent,
-	# or deleting the node directly via the nodeTools dialog
-	restoreDeletedNode = (target, parent) ->
-
-		unless cache[target] then return
-
-		item = cache[target]
-
-		# Splice the answer and node back into their respective arrays at their previous index positions
-		if parent.answers then parent.answers.splice item.answerIndex, 0, item.answer # !parent.answers only occurs if you're deleting a child of a blank [in-between] node
-		parent.contents.splice item.nodeIndex, 0, item.node
-		# Remove the node from the cryo cache
-		cache.splice target, 1
-
-		restoreExistingLinks parent.contents[item.nodeIndex]
-
-		# Restore pendingTarget property to parent
-		if item.parentHasPendingTarget then parent.pendingTarget = target
-
-		# Grab the tree to update answer links & manually refresh it
-		tree = treeSrv.get()
-
-		# Update the tree to display the restored node
-		treeSrv.set tree
-
-		# Refresh all answerLinks references as some have changed
-		treeSrv.updateAllAnswerLinks tree
-
-		return tree
-
-	# Reset nodes hold the original state of the node in cryo, but instead of appending data back into the contents[] and answers[] arrays of the parent,
-	# We overwrite the blank node that replaced it
-	restoreResetNode = (target, parent) ->
-
-		unless cache[target] then return
-
-		item = cache[target]
-		tree = treeSrv.get()
-
-		if parent
-			# Replace the reset node with the original
-			parent.answers[item.answerIndex] = item.answer
-			parent.contents[item.nodeIndex] = item.node
-			cache.splice target, 1
-
-			restoreExistingLinks parent.contents[item.nodeIndex]
-
-		else
-			# Special case if the user reset the Start node, which has no parent
-			tree = treeSrv.findAndReplace tree, target, item.node
-
-		# Update the tree to display the restored node
-		treeSrv.set tree
-
-		# Refresh all answerLinks references as some have changed
-		treeSrv.updateAllAnswerLinks tree
-
-		return tree
-
-	# Changing an answer's target from a new node to an existing one removes the original hierarchical child. Restoring it requires unique logic relative to deleted or reset nodes
-	restoreUnlinkedNode = (target, parent) ->
-
-		unless cache[target] then return
-
-		item = cache[target]
-
-		parent.answers[item.answerIndex] = item.answer
-		parent.contents.splice item.nodeIndex, 0, item.node
-		cache.splice target, 1
-
-		restoreExistingLinks parent.contents[item.nodeIndex]
-
-		# Check to see if we have to remove either the hasLinkToOther or hasLinkToSelf flags
-		# The parent node will have one or the other depending on the link type being undone
-		# However, the flag may be retained if other self/existing links exist
-		removeLinksToOtherFlag = true
-		removeLinksToSelfFlag = true
-		angular.forEach parent.answers, (answer, index) ->
-			if answer.linkMode is "existing"
-				removeLinksToOtherFlag = false
-
-			if answer.linkMode is "self"
-				removeLinksToSelfFlag = false
-
-		if parent.hasLinkToOther and removeLinksToOtherFlag then delete parent.hasLinkToOther
-		if parent.hasLinkToSelf and removeLinksToSelfFlag then delete parent.hasLinkToSelf
-
-		# Grab tree object to update answer links & manually refresh it
-		tree = treeSrv.get()
-		treeSrv.set tree
-
-		# Refresh all answerLinks references as some have changed
-		treeSrv.updateAllAnswerLinks tree
-
-	# Within the subtree that is going to be deleted, recurse through it and identify if an existing link is pointing to each node.
-	# If one is, add the "otherLinks" parameter which holds a record of this link for the purposes of restoring
-	cacheExistingLinks = (subtree) ->
-
-		otherLinks = []
-		for linkIndex, link of subtree.answerLinks
-			unless link.parent is subtree.parent
-				tree = treeSrv.get()
-
-				# Have to get the tree and identify the node that has the existing link pointing to this particular node
-				otherLink = treeSrv.findNode tree, link.parent
-
-				# Identify the answer associated with that existing link and save its index position
-				angular.forEach otherLink.answers, (answer, index) ->
-
-					if answer.target is subtree.id and answer.linkMode is "existing"
-
-						otherLinks.push
-							id :	otherLink.id
-							answerIndex: index
-
-		if otherLinks.length
-			subtree.otherLinks = otherLinks # add the otherLinks parameter to this node
-
-		# Now recurse through the tree and apply this logic to all nodes in the subtree
-		if !subtree.contents then return
-
-		i = 0
-
-		while i < subtree.contents.length
-
-			child = subtree.contents[i]
-
-			cacheExistingLinks child
-
-			i++
-
-		return
-
-	# This recursive function does the opposite of cacheExistingLinks; now we recurse through the subtree that's being restored and re-implement all the existing links
-	# This requires removing the new, blank nodes that were made to replace them and re-applying the existing links
-	# A prerequisite not present in deleteAndRestoreSrv is found in treeSrv's findAndFixAnswerTargets: the replacementForTarget property is applied to all of these new, blank nodes that replaced existing links
-	restoreExistingLinks = (node) ->
-
-		if node.otherLinks
-
-			tree = treeSrv.get()
-
-			for index, link of node.otherLinks
-
-				otherNode = treeSrv.findNode tree, link.id
-
-				spliceTargetIndex = null
-
-				for child, childIndex in otherNode.contents
-					if child.replacementForTarget and child.replacementForTarget is node.id then spliceTargetIndex = childIndex
-
-				if typeof otherNode.contents[spliceTargetIndex] isnt 'undefined' then otherNode.contents.splice spliceTargetIndex, 1
-				otherNode.answers[link.answerIndex].target = node.id
-				otherNode.answers[link.answerIndex].linkMode = "existing"
-
-				otherNode.hasLinkToOther = true
-
-			delete node.otherLinks
-
-		# Recurse through the subtree and perform this action for all other nodes
-		if !node.contents then return
-
-		i = 0
-
-		while i < node.contents.length
-
-			child = node.contents[i]
-
-			restoreExistingLinks child
-
-			i++
-
-		return
-
-	get : get
-	set : set
-	add : add
-	coldStorage : coldStorage
-	restoreDeletedNode : restoreDeletedNode
-	restoreResetNode : restoreResetNode
-	restoreUnlinkedNode : restoreUnlinkedNode
-	cacheExistingLinks : cacheExistingLinks
-	restoreExistingLinks : restoreExistingLinks
 ]

--- a/src/src-assets/creator-assets/services.coffee
+++ b/src/src-assets/creator-assets/services.coffee
@@ -748,6 +748,10 @@ Adventure.service "treeHistorySrv", ['treeSrv', '$rootScope', (treeSrv, $rootSco
 		NODE_ANSWER_REMOVED: "NODE_ANSWER_REMOVED"
 		NODE_PARENT_REMOVED: "NODE_PARENT_REMOVED"
 		NODE_REPLACED_WITH_EXISTING: "NODE_REPLACED_WITH_EXISTING"
+		NODE_ADDED_IN_BETWEEN: "NODE_ADDED_IN_BETWEEN"
+		NODE_EDITED: "NODE_EDITED"
+		NODE_COPIED: "NODE_COPIED"
+		NODE_CONVERTED : "NODE_CONVERTED"
 
 	getActions = () ->
 		return actions
@@ -761,6 +765,7 @@ Adventure.service "treeHistorySrv", ['treeSrv', '$rootScope', (treeSrv, $rootSco
 			context: context ? context : ""
 			timestamp : Date.now()
 			tree: JSON.stringify(tree)
+			nodeCount : treeSrv.getNodeCount()
 
 	addToHistory = (tree, action, context) ->
 		snapshot = createSnapshot tree, action, context
@@ -771,13 +776,16 @@ Adventure.service "treeHistorySrv", ['treeSrv', '$rootScope', (treeSrv, $rootSco
 		history.splice(index, 1)
 		$rootScope.$broadcast "tree.history.updated"
 
-	applySnapshot = (index) ->
-		snappedTree = JSON.parse history[index].tree
-		treeSrv.set snappedTree
+	retrieveSnapshot = (index) ->
+		# snappedTree = JSON.parse history[index].tree
+		# treeSrv.set snappedTree
 		
-		if history.length > 10 then history.splice 10, 1
+		# if history.length > 10 then history.splice 10, 1
 		
-		return snappedTree
+		# return snappedTree
+		snapshot = history[index]
+		if history.length > 40 then history.splice 40, 1
+		return snapshot
 
 
 	getActions : getActions
@@ -785,6 +793,6 @@ Adventure.service "treeHistorySrv", ['treeSrv', '$rootScope', (treeSrv, $rootSco
 	createSnapshot : createSnapshot
 	addToHistory : addToHistory
 	removeFromHistory : removeFromHistory
-	applySnapshot : applySnapshot
+	retrieveSnapshot : retrieveSnapshot
 
 ]


### PR DESCRIPTION
Still WIP.

Removes `deleteAndRestoreSrv` and references.
Added `treeHistorySrv` for tree snapshotting and restoration.

Added initial hooks for snapshotting tied to certain events: node removal, answer removal, etc.