### PR TITLE
Node management and deletion improvements

### DIFF
--- a/src/creator.html
+++ b/src/creator.html
@@ -25,6 +25,12 @@
 
 	</head>
 	<body ng-controller="AdventureCtrl" id="body">
+		<mode-manager-overlay
+			ng-class="{'enabled':showModeManager}">
+			{{modeManagerMessage}}
+			<button type="button"
+				ng-click="modeManagerAction()">{{modeManagerActionText}}</button>
+		</mode-manager-overlay>	
 		<header class="title-header">
 			<img class="logo" src="assets/creator-assets/materialogo.png" alt="Materia Logo" />
 			<h1 id="title" ng-click="showTitleEditor = true">{{title}}</h1>
@@ -43,9 +49,6 @@
 			<!-- <button type="button" class="temp-qset-gen-button" ng-click="onSaveClicked('publish')">Simulate Publish</button> -->
 		</header>
 		<div id="adventure-container">
-			<div class="mode-header" ng-show="showModeManager">
-				{{modeHeaderText}}
-			</div>
 			<div class="zoom-buttons" zoom-buttons>
 				<div class="zoom-status">{{(treeOffset.scale * 100).toFixed(0)}}%</div>
 				<svg class="zoom-button"
@@ -299,12 +302,6 @@
 				ng-click="hideToast()">
 				{{toastMessage}}
 			</toast>
-			<mode-manager
-				ng-show="showModeManager">
-				{{modeManagerMessage}}
-				<button type="button"
-					ng-click="modeManagerAction()">{{modeManagerActionText}}</button>
-			</mode-manager>
 			<node-tools-dialog
 				id="nodeTools"
 				ng-show="nodeTools.show"

--- a/src/creator.html
+++ b/src/creator.html
@@ -43,6 +43,9 @@
 			<!-- <button type="button" class="temp-qset-gen-button" ng-click="onSaveClicked('publish')">Simulate Publish</button> -->
 		</header>
 		<div id="adventure-container">
+			<div class="mode-header" ng-show="showModeManager">
+				{{modeHeaderText}}
+			</div>
 			<div class="zoom-buttons" zoom-buttons>
 				<div class="zoom-status">{{(treeOffset.scale * 100).toFixed(0)}}%</div>
 				<svg class="zoom-button"
@@ -254,13 +257,15 @@
 					ng-click="hideCoverAndModals()">Got It!</button>
 			</validation-dialog>
 			<toast ng-hide="!showToast"
-				ng-click="hideToast()"
-				class="fadeable">
+				ng-click="hideToast()">
 				{{toastMessage}}
-				<button type="button"
-					ng-show="showToastActionButton"
-					ng-click="toastAction()">{{toastActionText}}</button>
 			</toast>
+			<mode-manager
+				ng-show="showModeManager">
+				{{modeManagerMessage}}
+				<button type="button"
+					ng-click="modeManagerAction()">{{modeManagerActionText}}</button>
+			</mode-manager>
 			<node-tools-dialog
 				id="nodeTools"
 				ng-show="nodeTools.show"
@@ -707,7 +712,7 @@
 						ng-click="hideCoverAndModals()">Done</button>
 				</div>
 			</div>
-			<tree-history ng-class="{ 'minimized':minimized }">
+			<tree-history ng-class="{ 'minimized':minimized, 'disabled': (existingNodeSelectionMode || copyNodeMode)}" ng-disabled="existingNodeSelectionMode || copyNodeMode">
 				<div class="undo-redo-options">
 					<button ng-click="undoAction()" ng-disabled="historyPosition <= 0">Undo</button>
 					<button ng-click="redoAction()" ng-disabled="historyPosition >= historySize-1">Redo</button>

--- a/src/src-assets/creator-assets/controllers.coffee
+++ b/src/src-assets/creator-assets/controllers.coffee
@@ -162,7 +162,7 @@ Adventure.controller "AdventureCtrl", ['$scope', '$filter', '$compile', '$rootSc
 					$scope.editedNode.hasProblem = true
 
 			# Handy debugging statement here; keep it commented out unless necessary for testing
-			# console.log $scope.editedNode
+			console.log $scope.editedNode
 
 			# Redraw tree (again) to address any post-edit changes
 			treeSrv.set $scope.treeData

--- a/src/src-assets/creator-assets/controllers.coffee
+++ b/src/src-assets/creator-assets/controllers.coffee
@@ -187,6 +187,8 @@ Adventure.controller "AdventureCtrl", ['$scope', '$filter', '$compile', '$rootSc
 		$scope.validation.show = false
 		$scope.showScoreModeDialog = false
 
+		$scope.resetNewNodeManager()
+
 		$scope.displayNodeCreation = "none"
 
 	materiaCallbacks.initNewWidget = (widget, baseUrl) ->

--- a/src/src-assets/creator-assets/controllers.coffee
+++ b/src/src-assets/creator-assets/controllers.coffee
@@ -162,7 +162,7 @@ Adventure.controller "AdventureCtrl", ['$scope', '$filter', '$compile', '$rootSc
 					$scope.editedNode.hasProblem = true
 
 			# Handy debugging statement here; keep it commented out unless necessary for testing
-			console.log $scope.editedNode
+			# console.log $scope.editedNode
 
 			# Redraw tree (again) to address any post-edit changes
 			treeSrv.set $scope.treeData

--- a/src/src-assets/creator-assets/creator.scss
+++ b/src/src-assets/creator-assets/creator.scss
@@ -507,6 +507,19 @@ button {
 	}
 }
 
+.mode-header {
+	position: absolute;
+	top: 0px;
+	right: 0px;
+	padding: 6px 15px;
+
+	background: $blue-lighter;
+	color: $color-primary;
+
+	text-align: right;
+	border-bottom-left-radius: 5px;
+}
+
 .zoom-buttons {
 	position: absolute;
 	top: 15px;
@@ -753,7 +766,7 @@ toast {
 	width: 600px;
 	min-height: 30px;
 
-	bottom: 45px;
+	bottom: 80px;
 	left: 50%;
 	margin-left: -300px;
 
@@ -767,6 +780,29 @@ toast {
 
 	background: $gray-darker;
 	box-shadow: $shadow-small;
+}
+
+mode-manager {
+	position: absolute;
+	z-index: $z-index-very-important;
+
+	width: 600px;
+	min-height: 30px;
+
+	bottom: 35px;
+	left: 50%;
+	margin-left: -300px;
+
+	padding-top: 5px;
+
+	border-radius: 5px;
+
+	text-align: center;
+
+	color: $color-primary;
+
+	background: $color-accent;
+	box-shadow: $shadow-small;
 
 	button {
 		position: absolute;
@@ -776,14 +812,6 @@ toast {
 
 		font-size: 14px;
 	}
-
-	// &.fadeable {
-	// 	transition: 0.5s linear all;
-	// 	opacity: 1;
-	// 	&.ng-hide {
-	// 		opacity: 0;
-	// 	}
-	// }
 }
 
 node-tooltips {
@@ -945,6 +973,34 @@ tree-history {
 			transition: background 500ms;
 			cursor: pointer;
 		}
+	}
+
+	&.disabled {
+		div.undo-redo-options {
+			button {
+				color: $gray-lightest;
+
+				&:hover {
+					color: $gray-lightest;
+				}
+			}
+		}
+		header {
+			background: $gray;
+			cursor: default;
+
+			&:hover {
+				background: $gray;
+			}
+		}
+
+		div.action-history {
+			color: $gray;
+			&:hover {
+				background: $gray-lightest;
+			}
+		}
+		
 	}
 }
 

--- a/src/src-assets/creator-assets/creator.scss
+++ b/src/src-assets/creator-assets/creator.scss
@@ -200,14 +200,15 @@ mode-manager-overlay {
 	
 	top: -60px;
 	left: 0;
-	width: 90%;
+	width: 100%;
 	height: 42px;
 
 	padding-top: 18px;
-	padding-left: 10%;	
 
 	color: $color-primary;
 	background: $color-mode-accent;
+
+	text-align: center;
 
 	font-size: 1.1em;
 
@@ -220,7 +221,7 @@ mode-manager-overlay {
 	button {
 		position: absolute;
 		top: 15px;
-		right: 25%;
+		right: 20%;
 		padding: 6px 18px;
 		text-align: center;
 

--- a/src/src-assets/creator-assets/creator.scss
+++ b/src/src-assets/creator-assets/creator.scss
@@ -14,6 +14,8 @@ $blue: #3d90b1;
 $blue-lighter: #49afd7;
 $blue-lightest: #bdecff;
 
+$tealish: #61a47f;
+
 $gray-darker: #333333;
 $gray: #888888;
 $gray-lighter: #cccccc;
@@ -25,6 +27,7 @@ $color-primary: $white;
 $color-accent: $blue;
 $color-accent-highlight: $blue-lighter;
 $color-selection-hover: $blue-lightest;
+$color-mode-accent: $tealish;
 
 $color-blank: #ADADAD;
 $color-mc: #60b973;
@@ -378,6 +381,14 @@ g.node {
 		}
 	}
 
+	&.ineligible {
+		circle.node-dot {
+			fill: $red-lightest;
+			stroke: $red !important;
+			stroke-width: 3px !important;
+		}
+	}
+
 	rect {
 		fill: $white;
 		stroke: $gray-lightest;
@@ -513,7 +524,7 @@ button {
 	right: 0px;
 	padding: 6px 15px;
 
-	background: $blue-lighter;
+	background: $color-mode-accent;
 	color: $color-primary;
 
 	text-align: right;
@@ -801,7 +812,7 @@ mode-manager {
 
 	color: $color-primary;
 
-	background: $color-accent;
+	background: $color-mode-accent;
 	box-shadow: $shadow-small;
 
 	button {

--- a/src/src-assets/creator-assets/creator.scss
+++ b/src/src-assets/creator-assets/creator.scss
@@ -194,6 +194,40 @@ div.fancy-toggle {
 	}
 }
 
+mode-manager-overlay {
+	position: absolute;
+	z-index: $z-index-very-important;
+	
+	top: -60px;
+	left: 0;
+	width: 90%;
+	height: 42px;
+
+	padding-top: 18px;
+	padding-left: 10%;	
+
+	color: $color-primary;
+	background: $color-mode-accent;
+
+	font-size: 1.1em;
+
+	transition: all 0.5s;
+
+	&.enabled {
+		top:0;
+	}
+
+	button {
+		position: absolute;
+		top: 15px;
+		right: 25%;
+		padding: 6px 18px;
+		text-align: center;
+
+		font-size: 15px;
+	}
+}
+
 header.title-header {
 	display: block;
 	width: 100%;
@@ -779,7 +813,7 @@ toast {
 	width: 600px;
 	min-height: 30px;
 
-	bottom: 80px;
+	bottom: 35px;
 	left: 50%;
 	margin-left: -300px;
 
@@ -793,38 +827,6 @@ toast {
 
 	background: $gray-darker;
 	box-shadow: $shadow-small;
-}
-
-mode-manager {
-	position: absolute;
-	z-index: $z-index-very-important;
-
-	width: 600px;
-	min-height: 30px;
-
-	bottom: 35px;
-	left: 50%;
-	margin-left: -300px;
-
-	padding-top: 5px;
-
-	border-radius: 5px;
-
-	text-align: center;
-
-	color: $color-primary;
-
-	background: $color-mode-accent;
-	box-shadow: $shadow-small;
-
-	button {
-		position: absolute;
-		right: 5px;
-		height:24px;
-		text-align: center;
-
-		font-size: 14px;
-	}
 }
 
 node-tooltips {

--- a/src/src-assets/creator-assets/directives.coffee
+++ b/src/src-assets/creator-assets/directives.coffee
@@ -26,18 +26,15 @@ Adventure.directive "toast", ['$timeout', ($timeout) ->
 			$scope.toastMessage = ""
 ]
 
-Adventure.directive "modeManager", [() ->
+Adventure.directive "modeManagerOverlay", [() ->
 	restrict: "E",
 	link: ($scope, $element, $attrs) ->
-
-		$scope.modeHeaderText = false
 
 		$scope.showModeManager = false
 		$scope.modeManagerMessage = ""
 		$scope.modeManagerActionText = ""
 
-		$scope.displayModeManager = (header, message, actionText, action) ->
-			$scope.modeHeaderText = header
+		$scope.displayModeManager = (message, actionText, action) ->
 			$scope.modeManagerMessage = message
 			$scope.modeManagerActionText = actionText
 			$scope.modeManagerAction = action
@@ -907,7 +904,7 @@ Adventure.directive "nodeToolsDialog", ['treeSrv', 'treeHistorySrv','$rootScope'
 
 			$rootScope.$broadcast "mode.copy"
 
-			$scope.displayModeManager "Copy Destination Mode", "Select an appropriate blank destination as your copy target.", "Cancel", ->
+			$scope.displayModeManager "Select an appropriate blank destination as your copy target.", "Cancel", ->
 				$scope.cancelModeManager()
 				$scope.copyNodeMode = false
 				$scope.copyNodeTarget = null
@@ -1369,7 +1366,7 @@ Adventure.directive "newNodeManagerDialog", ['treeSrv', 'treeHistorySrv', '$docu
 					$rootScope.$broadcast "mode.existingLink"
 					treeSrv.set $scope.treeData
 
-					$scope.displayModeManager "Existing Answer Selection Mode", "Select the destination this answer should link to.", "Cancel", ->
+					$scope.displayModeManager "Select the destination this answer should link to.", "Cancel", ->
 						$rootScope.$broadcast "mode.existingLink.complete"
 						$scope.existingNodeSelectionMode = false
 						$scope.displayNodeCreation = $scope.editedNode.type

--- a/src/src-assets/creator-assets/directives.coffee
+++ b/src/src-assets/creator-assets/directives.coffee
@@ -48,7 +48,6 @@ Adventure.directive "modeManager", [() ->
 			$scope.showModeManager = false
 			$scope.modeManagerMessage = ""
 			$scope.modeManagerActionText = ""
-			$scope.modeManagerActionText = actionText
 			$scope.modeManagerAction = null
 ]
 
@@ -225,7 +224,7 @@ Adventure.directive "treeVisualization", ['treeSrv', '$window', '$compile', '$ro
 
 				# Right now, we're disabling bridge nodes on loopbacks
 				# Might add them back in later
-				if link.specialCase is "loopBack" then return
+				if link.specialCase is "loopBack" or $scope.copyMode or $scope.existingLinkMode then return
 				else
 					intermediate =
 						x: source.x + (target.x - source.x)/2

--- a/src/src-assets/creator-assets/directives.coffee
+++ b/src/src-assets/creator-assets/directives.coffee
@@ -216,12 +216,14 @@ Adventure.directive "treeVisualization", ['treeSrv', '$window', '$compile', '$ro
 			# The properties of the link and intermediate "bridge" nodes depends on what kind of link we have
 			angular.forEach links, (link, index) ->
 
+				# Don't create bridge nodes if copyMode or existingLinkMode are enabled
+				if $scope.copyMode or $scope.existingLinkMode then return
+
 				source = link.source
 				target = link.target
 
-				# Right now, we're disabling bridge nodes on loopbacks
-				# Might add them back in later
-				if link.specialCase is "loopBack" or $scope.copyMode or $scope.existingLinkMode then return
+				# Disable bridge nodes on loopbacks
+				if link.specialCase is "loopBack" then return
 				else
 					intermediate =
 						x: source.x + (target.x - source.x)/2
@@ -357,6 +359,9 @@ Adventure.directive "treeVisualization", ['treeSrv', '$window', '$compile', '$ro
 
 						return "M" + d.source.x + "," + d.source.y + "A" + dr + "," + dr + " 0 0,1 " + d.target.x + "," + d.target.y
 					)
+
+					# don't attempt the following calculations if in copyMode or existingLinkMode! These nodes will not exist
+					if $scope.copyMode or $scope.existingLinkMode then return
 
 					# Do some fancy math to find the midpoint of the curve once it's been computed
 					# This must happen AFTER the path is generated for the link

--- a/src/src-assets/creator-assets/directives.coffee
+++ b/src/src-assets/creator-assets/directives.coffee
@@ -1117,9 +1117,17 @@ Adventure.directive "nodeToolsDialog", ['treeSrv', 'treeHistorySrv','$rootScope'
 
 				newTargetNode.parentId = parent.id
 
-				treeSrv.findAndReplace $scope.treeData, $scope.nodeTools.target, newTargetNode
+				if targetAnswerIndex is null and parent.pendingTarget then parent.pendingTarget = newTargetNode.id # super duper edge case in case the parent is ALSO a blank in-between node
+				else parent.answers[targetAnswerIndex].target = newTargetNode.id # set the parent's answer target back to the correct node id
 
-				parent.answers[targetAnswerIndex].target = newTargetNode.id
+				# Handle resolution different depending on whether or not the in-between node has an existing link or normal link to its pendingTarget
+				if target.hasLinkToOther
+					parent.hasLinkToOther = true
+					if targetAnswerIndex isnt null then parent.answers[targetAnswerIndex].linkMode = $scope.EXISTING
+					treeSrv.findAndRemove $scope.treeData, $scope.nodeTools.target
+				else
+					treeSrv.findAndReplace $scope.treeData, $scope.nodeTools.target, newTargetNode
+					
 
 			else # default behavior
 
@@ -1736,8 +1744,6 @@ Adventure.directive "nodeCreation", ['treeSrv','legacyQsetSrv', 'treeHistorySrv'
 				for id in removed
 					treeSrv.findAndFixAnswerTargets $scope.treeData, id
 
-				# Display the interactive toast that provides the Undo option
-				# Toast is displayed until clicked or until the node creation screen is closed
 				$scope.toast "Destination " + $scope.integerToLetters(targetId) + " was deleted."
 			else
 				# Just remove it from answers array, no further action required

--- a/src/src-assets/creator-assets/directives.coffee
+++ b/src/src-assets/creator-assets/directives.coffee
@@ -909,7 +909,7 @@ Adventure.directive "nodeToolsDialog", ['treeSrv', 'treeHistorySrv','$rootScope'
 
 			$rootScope.$broadcast "mode.copy"
 
-			$scope.displayModeManager "Select an appropriate blank destination as your copy target.", "Cancel", ->
+			$scope.displayModeManager "Select a blank destination as your copy target.", "Cancel", ->
 				$scope.cancelModeManager()
 				$scope.copyNodeMode = false
 				$scope.copyNodeTarget = null

--- a/src/src-assets/creator-assets/directives.coffee
+++ b/src/src-assets/creator-assets/directives.coffee
@@ -23,6 +23,7 @@ Adventure.directive "toast", ['$timeout', ($timeout) ->
 
 		$scope.hideToast = () ->
 			$scope.showToast = false
+			$scope.toastMessage = ""
 ]
 
 Adventure.directive "modeManager", [() ->
@@ -45,6 +46,10 @@ Adventure.directive "modeManager", [() ->
 
 		$scope.cancelModeManager = () ->
 			$scope.showModeManager = false
+			$scope.modeManagerMessage = ""
+			$scope.modeManagerActionText = ""
+			$scope.modeManagerActionText = actionText
+			$scope.modeManagerAction = null
 ]
 
 Adventure.directive "enterSubmit", ['$compile', ($compile) ->

--- a/src/src-assets/creator-assets/services.coffee
+++ b/src/src-assets/creator-assets/services.coffee
@@ -731,6 +731,7 @@ Adventure.service "treeSrv", ['$rootScope','$filter','$sanitize','legacyQsetSrv'
 	findAndAddInBetween : findAndAddInBetween
 	findAndRemove : findAndRemove
 	findAndFixAnswerTargets : findAndFixAnswerTargets
+	getIdsFromSubtree : getIdsFromSubtree
 	createQSetFromTree : createQSetFromTree
 	createTreeDataFromQset : createTreeDataFromQset
 	validateTreeOnStart : validateTreeOnStart

--- a/src/src-assets/creator-assets/services.coffee
+++ b/src/src-assets/creator-assets/services.coffee
@@ -474,7 +474,6 @@ Adventure.service "treeSrv", ['$rootScope','$filter','$sanitize','legacyQsetSrv'
 			if tree.hasLinkToOther then itemData.options.hasLinkToOther = true
 			if tree.hasLinkToSelf then itemData.options.hasLinkToSelf = true
 			if tree.pendingTarget then itemData.options.pendingTarget = tree.pendingTarget
-			# TODO should cryo cache be included in QSet?
 
 			angular.forEach tree.answers, (answer, index) ->
 
@@ -503,7 +502,7 @@ Adventure.service "treeSrv", ['$rootScope','$filter','$sanitize','legacyQsetSrv'
 		i = 0
 
 		while i < tree.children.length
-
+			
 			child = tree.children[i]
 			items = formatTreeDataForQset child, items
 			i++


### PR DESCRIPTION
Contains improvements originally suggested in #11:

- Deleting a **blank** in-between node will now restore the in-between node's original parent and child, instead of removing the blank node, its immediate child (the original child), and the entire subtree.
- Several fixes to improve robustness of the existing link selection mode, including preventing a user from selecting a descendant of the answer's original child node. Doing so would previously create a time-space continuum paradox (and also break the widget)
- Replaced interactive toasts with a dedicated Mode Selection toast. The Mode Selection toast will appear below existing toasts so the two can coexist when required and is now using a unique teal accent color to differentiate it from a normal toast.
- Provided additional visual indicators to show the user is in Existing Node Selection or Copy Mode, including a subheader bar at the top right, disabling Action History, and visually identifying ineligible nodes when in Existing Node Selection