### PR TITLE
hasLinkToOther was not scrubbed when converting a node from Narrative to End Point

### DIFF
--- a/src/src-assets/creator-assets/directives.coffee
+++ b/src/src-assets/creator-assets/directives.coffee
@@ -1194,6 +1194,10 @@ Adventure.directive "nodeToolsDialog", ['treeSrv', 'treeHistorySrv','$rootScope'
 					delete node.children
 					delete node.answers
 
+					# if the answer was an existing link or loopback link (you jerk!) and not a regular one, this flag must also be removed
+					if node.hasLinkToOther then delete node.hasLinkToOther
+					if node.hasLinkToSelf then delete node.hasLinkToSelf
+
 					treeSrv.set $scope.treeData
 
 			# Buncha nonsense required to add the default [Unmatched Response] required for shortans

--- a/src/src-assets/creator-assets/services.coffee
+++ b/src/src-assets/creator-assets/services.coffee
@@ -612,6 +612,23 @@ Adventure.service "treeSrv", ['$rootScope','$filter','$sanitize','legacyQsetSrv'
 
 					errors.push error
 
+			if node.hasLinkToOther or node.hasLinkToSelf
+
+				existingCount = 0
+				selfCount = 0
+
+				angular.forEach node.answers, (answer, answerIndex) ->
+
+					if answer.linkMode is "existing" then existingCount++
+					else if answer.linkMode is "self" then selfCount++
+
+				if existingCount is 0 and node.hasLinkToOther
+					delete node.hasLinkToOther
+					console.warn "Warning: Node " + node.name + " retained the hasLinkToOther flag but no existing links existed. The flag was removed."
+				if selfCount is 0 and node.hasLinkToSelf
+					delete node.hasLinkToSelf
+					console.warn "Warning: Node " + node.name + " retained the hasLinkToSelf flag but no self links existed. The flag was removed."
+
 		return errors
 
 	validateTreeOnSave = (tree) ->


### PR DESCRIPTION
The property will now be scrubbed, and validation has been added to the onStart validator