### PR TITLE
Prompt Mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "version": "2.5.1",
   "dependencies": {
-    "materia-widget-development-kit": "^3.0.2",
+    "materia-widget-development-kit": "^3.0.3",
     "micromarkdown": "^0.3.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "version": "2.5.1",
   "dependencies": {
-    "materia-widget-development-kit": "^3.0.3",
+    "materia-widget-development-kit": "^3.0.2",
     "micromarkdown": "^0.3.0"
   },
   "scripts": {

--- a/src/creator.html
+++ b/src/creator.html
@@ -16,9 +16,9 @@
 		<script src="materia.creatorcore.js"></script>
 
 		<!-- YOUR PREREQUISITES -->
-		<script src='//cdnjs.cloudflare.com/ajax/libs/angular.js/1.6.9/angular.min.js'></script>
-		<script src='//cdnjs.cloudflare.com/ajax/libs/angular.js/1.6.9/angular-animate.min.js'></script>
-		<script src='//cdnjs.cloudflare.com/ajax/libs/angular.js/1.6.9/angular-sanitize.min.js'></script>
+		<script src='//cdnjs.cloudflare.com/ajax/libs/angular.js/1.8.3/angular.min.js'></script>
+		<script src='//cdnjs.cloudflare.com/ajax/libs/angular-animate/1.8.3/angular-animate.min.js'></script>
+		<script src='//cdnjs.cloudflare.com/ajax/libs/angular-sanitize/1.8.3/angular-sanitize.min.js'></script>
 		<script src="//cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js" charset="utf-8"></script>
 		<script src="//cdn.skypack.dev/d3-drag@3" charset="utf-8"></script>
 
@@ -58,6 +58,18 @@
 			</section>
 		</header>
 		<div id="adventure-container">
+			<div class="ai-toolbar" ng-if="allowPromptMode">
+				<div class="prompt-mode-toggle">
+					Prompt Mode
+					<div class="options-check-slide fancy-toggle">
+						<input type="checkbox" ng-model="promptMode" id="prompt-mode-options-check-slide-input"/>
+						<label for="prompt-mode-options-check-slide-input"></label>
+					</div>
+				</div>
+				<button ng-disabled="promptMode == false" ng-click="showScenarioDialog = true">
+					Scenario Description
+				</button>
+			</div>
 			<div class="inert-on-dialog" aria-hidden="showBackgroundCover || showInventoryBackgroundCover">
 				<div class="zoom-buttons" zoom-buttons>
 					<div class="zoom-status">{{(treeOffset.scale * 100).toFixed(0)}}%</div>
@@ -195,6 +207,13 @@
 						ng-click="saveAndCloseInventory()">Done</button>
 				</div>
 			</item-manager>
+			<prompt-mode-scenario-dialog ng-show="showScenarioDialog">
+				<h4>Scenario Description</h4>
+				<textarea
+					ng-model="promptModeScenario"
+					placeholder="Enter a brief description of the scenario. This will provide an overall context to the AI for roleplay purposes."></textarea>
+				<button type="button" ng-click="showScenarioDialog = false">Close</button>
+			</prompt-mode-scenario-dialog>
 			<debug-qset-generator ng-show="showQsetGenerator">
 				<h4>Generated QSet</h4>
 				<textarea ng-model="generatedQset" auto-select></textarea>
@@ -1337,6 +1356,7 @@
 						</div>
 
 						<button ng-click="toggleQuestionsEditor()" id="advanced-question-btn">
+							<span ng-if="editedNode.questions.length > 1">{{editedNode.questions.length - 1}}</span>
 							Advanced Question Editor
 						</button>
 						<button type="button"

--- a/src/install.yaml
+++ b/src/install.yaml
@@ -10,6 +10,7 @@ general:
   is_answer_encrypted: Yes
   is_storage_enabled: No
   api_version: 2
+  uses_prompt_generation: Yes
 files:
   creator: creator.html
   player: player.html

--- a/src/player.html
+++ b/src/player.html
@@ -188,8 +188,8 @@
 				tabindex="0"
 				aria-label="Question: {{question.text}}, {{inventoryUpdateMessage}}"
 				ng-blur="dismissUpdates()">
-					<h2 class="text"
-					ng-class="layout"
+					<h2 class="text layout"
+					ng-class="{ 'is-loading-ai-response': question.is_loading_ai_response }"
 					ng-hide="question.text.length == 0"
 					auto-text-scale ng-bind-html="question.text" ng-if="layout != 'image-only'"></h2>
 					<span class="reader-instructions">{{inventoryUpdateMessage}}</span>

--- a/src/src-assets/creator-assets/controllers.coffee
+++ b/src/src-assets/creator-assets/controllers.coffee
@@ -25,6 +25,10 @@ angular.module "Adventure"
 	$scope.showImage = true
 	$scope.urlError = '　'
 
+	$scope.allowPromptMode = false
+	$scope.promptMode = false
+	$scope.promptModeScenario = ""
+
 	# Characters that need to be pre-sanitize before being run through angular's $sanitize directive
 	PRESANITIZE_CHARACTERS =
 		'>' : '&gt;',
@@ -244,6 +248,7 @@ angular.module "Adventure"
 				$scope.icons.push(custom_icon)
 
 	materiaCallbacks.initNewWidget = (widget, baseUrl) ->
+
 		$scope.$apply ->
 			$scope.title = "My Adventure Widget"
 
@@ -257,6 +262,13 @@ angular.module "Adventure"
 
 			treeHistorySrv.addToHistory $scope.treeData, historyActions.WIDGET_INIT, "Widget Initialized"
 
+			if widget.general # mwdk
+				if widget.general.uses_prompt_generation == "Yes"
+					$scope.allowPromptMode = true
+			else # materia itself maps these values differently
+				if widget.uses_prompt_generation == "1"
+					$scope.allowPromptMode = true
+
 	materiaCallbacks.initExistingWidget = (title,widget,qset,version,baseUrl) ->
 		showIntroDialog = false
 
@@ -269,6 +281,8 @@ angular.module "Adventure"
 				$scope.treeData = treeSrv.createTreeDataFromQset qset
 
 				if qset.options.hidePlayerTitle then $scope.hidePlayerTitle = qset.options.hidePlayerTitle
+				if qset.options.promptMode then $scope.promptMode = qset.options.promptMode
+				if qset.options.promptModeScenario then $scope.promptModeScenario = qset.options.promptModeScenario
 
 				treeSrv.setInventoryItems qset.options.inventoryItems || []
 
@@ -341,6 +355,8 @@ angular.module "Adventure"
 			qset.options.internalScoreMessage = $scope.internalScoreMessage
 			qset.options.inventoryItems = treeSrv.getInventoryItems()
 			qset.options.customIcons = treeSrv.getCustomIcons()
+			qset.options.promptMode = $scope.promptMode
+			qset.options.promptModeScenario = $scope.promptModeScenario
 			Materia.CreatorCore.save $scope.title, qset, 2
 
 	materiaCallbacks.onSaveComplete = (title, widget, qset, version) -> true

--- a/src/src-assets/creator-assets/creator.scss
+++ b/src/src-assets/creator-assets/creator.scss
@@ -857,7 +857,7 @@ button.temp-qset-gen-button {
 	margin-right: 25px;
 }
 
-debug-qset-loader, debug-qset-generator {
+debug-qset-loader, debug-qset-generator, prompt-mode-scenario-dialog {
 	position: absolute;
 	width: 450px;
 
@@ -2662,6 +2662,18 @@ node-creation-selection-dialog {
 
 	#advanced-question-btn {
 		margin-right: 20px;
+
+		span {
+			display: inline-flex;
+			align-items: center;
+			justify-content: center;
+			width: 1.5em;
+			height: 1.5em;
+			margin-right: 0.5em;
+			border-radius: 25%;
+			background: $red;
+			color: $white;
+		}
 	}
 
 	#big-upload-button {
@@ -4252,5 +4264,34 @@ import-type-selection {
 		top: -10px;
 		height: 35px;
 		width: 35px;
+	}
+}
+
+.ai-toolbar {
+	position: absolute;
+	bottom:0;
+	left: 0;
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	
+	// width: 500px;
+	// height: 2em;
+	padding: 0.5em 1em 0.5em 0.5em;
+
+	border-top-right-radius: 5px;
+	
+	color: #fff;
+	background: #327996;
+
+	.prompt-mode-toggle {
+		display: flex;
+		flex-direction: row;
+		align-items: center;
+		padding: 0 1em;
+
+		input[type="checkbox"] {
+			visibility: hidden;
+		}
 	}
 }

--- a/src/src-assets/creator-assets/directives.coffee
+++ b/src/src-assets/creator-assets/directives.coffee
@@ -3414,7 +3414,11 @@ angular.module "Adventure"
 			$scope.hideCoverAndModals()
 ]
 
-
+.directive "promptModeScenarioDialog", ['$rootScope', ($rootScope) ->
+	restrict: "E",
+	link: ($scope, $element, $attrs) ->
+		return
+]
 
 # MEANT FOR DEBUG PURPOSES ONLY
 .directive "debugQsetLoader", ['treeSrv', 'treeHistorySrv', 'legacyQsetSrv','$rootScope', (treeSrv, treeHistorySrv, legacyQsetSrv, $rootScope) ->

--- a/src/src-assets/player-assets/player.coffee
+++ b/src/src-assets/player-assets/player.coffee
@@ -192,10 +192,7 @@ angular.module('Adventure', ['ngAria', 'ngSanitize'])
 		# ****************************** prompt mode ****************************
 
 		if $scope.promptMode and parsedQuestion.length > 0 and parsedQuestion != "No question text provided."
-			console.log('submitting prompt: ' + parsedQuestion)
 			generationPrompt = _createPromptForQuestion(parsedQuestion)
-
-			console.log generationPrompt
 
 			Materia.Engine.submitPrompt(generationPrompt)
 

--- a/src/src-assets/player-assets/player.coffee
+++ b/src/src-assets/player-assets/player.coffee
@@ -38,8 +38,14 @@ angular.module('Adventure', ['ngAria', 'ngSanitize'])
 	$scope.missingRequiredItems = []
 	$scope.missingRequiredItemsAltText = ""
 
+	$scope.promptMode = false
+	$scope.promptModePreContext = ""
+
+	_roleplaySummary = ""
+	_lastResponseText = "The player has not yet made any decisions."
+
 	materiaCallbacks =
-		start: (instance, qset, version = '1') ->
+		start: (instance, qset, version = '1') -> (
 			#Convert an old qset prior to running the widget
 			if parseInt(version) is 1 then qset = JSON.parse legacyQsetSrv.convertOldQset qset
 
@@ -61,7 +67,46 @@ angular.module('Adventure', ['ngAria', 'ngSanitize'])
 
 				$scope.qsetHasInventoryItems = _qsetHasInventoryItems $scope.qset
 
+				if qset.options.promptMode
+					$scope.promptMode = qset.options.promptMode
+					$scope.promptModePreContext = qset.options.promptModeScenario
+
+					console.log 'prompt mode is ' + $scope.promptMode
+
 			$scope.showTutorial = true
+
+		),
+		promptResponse: (res) -> (
+
+			newQuestion = $scope.question
+			newQuestionText = $scope.question.text
+
+			try
+				responseJson = JSON.parse res[0]
+				if !!responseJson.roleplay
+					newQuestionText = micromarkdown.parse responseJson.roleplay
+					
+					if !!responseJson.summary then _roleplaySummary += " " + responseJson.summary
+				else newQuestionText = "There was an issue creating the roleplay for this question :("
+
+			catch e
+				newQuestion = "There was an issue decoding the roleplay for this question :("
+
+			$scope.$apply ->
+				$scope.question = {
+					...$scope.question,
+					text: newQuestionText,
+					is_loading_ai_response: false
+				}
+		
+		),
+		promptRejection: () ->
+			$scope.$apply ->
+				$scope.question = {
+					...$scope.question,
+					text: "Prompt rejected, there was an issue creating the roleplay for this question :(",
+					is_loading_ai_response: false
+				}
 
 		manualResize: true
 
@@ -143,13 +188,35 @@ angular.module('Adventure', ['ngAria', 'ngSanitize'])
 		# hyperlinks are automatically converted into <a href> tags, except it loads content within the iframe. To circumvent this, need to dynamically add target="_blank" attribute to all generated URLs
 		parsedQuestion = addTargetToHrefs parsedQuestion
 
-		$scope.question =
-			text : parsedQuestion, # questions MUST be an array, always 1 index w/ single text property. MMD converts markdown formatting into proper markdown syntax
-			layout: $scope.layout,
-			type : q_data.options.type,
-			id : q_data.options.id
-			materiaId: q_data.id
-			options: q_data.options
+
+		# ****************************** prompt mode ****************************
+
+		if $scope.promptMode and parsedQuestion.length > 0 and parsedQuestion != "No question text provided."
+			console.log('submitting prompt: ' + parsedQuestion)
+			generationPrompt = _createPromptForQuestion(parsedQuestion)
+
+			console.log generationPrompt
+
+			Materia.Engine.submitPrompt(generationPrompt)
+
+			parsedQuestion = "Loading..."
+
+			$scope.question =
+				text : parsedQuestion, # questions MUST be an array, always 1 index w/ single text property. MMD converts markdown formatting into proper markdown syntax
+				layout: $scope.layout,
+				type : q_data.options.type,
+				id : q_data.options.id
+				materiaId: q_data.id
+				options: q_data.options
+				is_loading_ai_response: true
+		else
+			$scope.question =
+				text : parsedQuestion, # questions MUST be an array, always 1 index w/ single text property. MMD converts markdown formatting into proper markdown syntax
+				layout: $scope.layout,
+				type : q_data.options.type,
+				id : q_data.options.id
+				materiaId: q_data.id
+				options: q_data.options
 
 		# ******************************************* inventory item management **************************************
 
@@ -301,7 +368,8 @@ angular.module('Adventure', ['ngAria', 'ngSanitize'])
 					hideRequiredItems: q_data.answers[i].options.hideRequiredItems || false
 
 				if answer.requiredItems[0]
-					$scope.showInventoryBtn = true
+					for item in answer.requiredItems[0]
+						if !item.isSilent then $scope.showInventoryBtn = true
 
 				$scope.answers.push answer
 
@@ -410,6 +478,8 @@ angular.module('Adventure', ['ngAria', 'ngSanitize'])
 		else
 			# record the answer
 			_logProgress()
+
+		_lastResponseText = $scope.selectedAnswer
 
 		if $scope.q_data.answers[index].options.feedback
 			$scope.feedback = $scope.q_data.answers[index].options.feedback
@@ -656,6 +726,10 @@ angular.module('Adventure', ['ngAria', 'ngSanitize'])
 			a[j] = a[i]
 			a[i] = t
 		a
+
+	_createPromptForQuestion = (questionPrompt) ->
+		summary = if _roleplaySummary.length then _roleplaySummary else "No summary available yet."
+		return "You will receive a prompt describing a branching roleplay scenerio, where the player makes choices to determine the scenerio outcome. Based on the scenerio context and summaries of each decision, address the player in the second-person: generate a few sentences to roleplay the current interaction. The overall description is: " + $scope.promptModePreContext + ". Building on the summary - " + summary + " - incorporating the user's last choice - " + _lastResponseText + " - continue the narrative: " + questionPrompt + ". Output ONLY a JSON object with two properties: 'roleplay' and 'summary', using the following structure: { roleplay: '', summary: '' }. 'roleplay' contains the actual roleplay content as requested as a string; 'summary' is a brief, one-sentence summary of the generated roleplay content. Do NOT include a code block, or any hidden characters that may otherwise make your response unreadable by a JSON parser."
 
 	# light this candle
 	Materia.Engine.start(materiaCallbacks)

--- a/src/src-assets/player-assets/player.scss
+++ b/src/src-assets/player-assets/player.scss
@@ -68,7 +68,7 @@ body {
 }
 
 .aria-live-region {
-	padding: 5px;
+	padding: 0;
 	box-sizing: border-box;
 	border: 2px solid transparent;
 	border-radius: 5px;
@@ -434,6 +434,17 @@ h1 {
 
 		b {
 			font-weight: bold;
+		}
+
+		&.is-loading-ai-response {
+			text-align: center;
+			animation: fade-in-out 2s infinite;
+
+			@keyframes fade-in-out {
+				0% { opacity: 0.25; }
+				50% { opacity: 1; }
+				100% { opacity: 0.25; }
+			}
 		}
 
 		// &.left {


### PR DESCRIPTION
WIP but functional implementation for Hack Day spring 2025. Enables "Prompt Mode", where node question text is instead fed as a prompt to a LLM in the player for a more dynamic roleplay experience.

- Adds `promptMode` and `promptModeScenario` values to qset options
- Adds hooks for Engine Core methods (NYI, created specifically for this project) that match prompt generation implementation in Creator Core
- Prompt submission and handling per-node in player

Required work before this ever saw the light of day on prod:

- More robust implementation of engine core prompt generation (ex: play session validation)
- Better error boundaries around missing or inoperable generation support from Materia
- Polish in creator explaining the purpose and functionality of Prompt Mode