### PR TITLE
Fix errors occuring when a blank node adventure is previewed and scored

### DIFF
--- a/src/_score/score_module.py
+++ b/src/_score/score_module.py
@@ -47,11 +47,9 @@ class Adventure(ScoreModule):
                             question.data.get("options")
                             .get("finalScore")
                         )
-
+            return 0
         else:
             return -1
-        
-        return 0
 
     def handle_log_question_answered(self, log):
         pass


### PR DESCRIPTION
The results screen would error out when previewing an adventure with no end nodes.

I added a base case to return the score as 0 if no end nodes are processed, mirroring the PhP version.
I also converted some of the type and ID checks to use strings instead of ints, as for some reason the log returns node ids as a string type. 

Changing the options type check at the start was necessary as on a blank node test I ran into a situation where the module would fail to cast the type into an int and error out.